### PR TITLE
Fix default value when item not set

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,11 @@ export class KeyValueStore {
     } catch (error) {
       value = defaultValue;
     }
+    
+    if (value == null) {
+      value = defaultValue;
+    }
+
     return value;
   }
 


### PR DESCRIPTION
The current implementation does not return the default value if the item is not set (tested on API25+).

The added `null` check fixes this.